### PR TITLE
fix #13: ShipmentService 멤버변수 nullpointerException 문제 해결

### DIFF
--- a/com.sparta-express.hub/src/main/java/com/sparta_express/hub/application/HubService.java
+++ b/com.sparta-express.hub/src/main/java/com/sparta_express/hub/application/HubService.java
@@ -15,6 +15,7 @@ public class HubService {
 
     private final HubRepositoryInfra hubRepo;
 
+
     @Cacheable(cacheNames = "hub", key = "#hubId.toString()")
     public Hub readHub(UUID hubId) {
 

--- a/com.sparta-express.hub/src/main/java/com/sparta_express/hub/application/ShipmentRouteService.java
+++ b/com.sparta-express.hub/src/main/java/com/sparta_express/hub/application/ShipmentRouteService.java
@@ -7,6 +7,7 @@ import com.sparta_express.hub.domain.model.InterhubRoute;
 import com.sparta_express.hub.domain.model.LastHubToDestination;
 import com.sparta_express.hub.infrastructure.map.MapApiInfra;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -21,31 +22,31 @@ public class ShipmentRouteService {
     private final MapApiInfra mapApi;
 
 
-//    @Cacheable(cacheNames = "shipmentInterhubRoutes",
-//            key = "#originHubId.toString() + #destinationHubId.toString()")
-    public final List<InterhubRoute> findShipmentInterhubRoutes(UUID originHubId,
-                                                                UUID destinationHubId) {
+    @Cacheable(cacheNames = "shipmentInterhubRoutes",
+            key = "#originHubId.toString() + #destinationHubId.toString()")
+    public List<InterhubRoute> findShipmentInterhubRoutes(UUID originHubId,
+                                                          UUID destinationHubId) {
 
         return shipmentRouteDomainService.findShipmentInterhubRoutes(
                 originHubId, destinationHubId
         );
     }
 
-    public final LastHubToDestination findFinalHubToDestination(String destinationAddress) {
+    public LastHubToDestination findLastHubToDestination(String destinationAddress) {
 
         return shipmentRouteDomainService.findFinalHubToDestination(
                 findGeometryPosition(destinationAddress)
         );
     }
 
-    protected final Hub findNearestHub(String address) {
+    protected Hub findNearestHub(String address) {
 
         return shipmentRouteDomainService.findNearestHub(
                 findGeometryPosition(address)
         );
     }
 
-    protected final Position findGeometryPosition(String address) {
+    protected Position findGeometryPosition(String address) {
 
         return mapApi.searchPosition(address);
     }

--- a/com.sparta-express.hub/src/main/java/com/sparta_express/hub/domain/ShipmentRouteDomainService.java
+++ b/com.sparta-express.hub/src/main/java/com/sparta_express/hub/domain/ShipmentRouteDomainService.java
@@ -1,10 +1,9 @@
 package com.sparta_express.hub.domain;
 
 import com.sparta_express.hub.domain.model.Hub;
-import com.sparta_express.hub.domain.model.LastHubToDestination;
 import com.sparta_express.hub.domain.model.InterhubRoute;
+import com.sparta_express.hub.domain.model.LastHubToDestination;
 import com.sparta_express.hub.domain.model.ShipmentRoute;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import org.springframework.stereotype.Component;
@@ -15,8 +14,6 @@ import java.util.stream.Collectors;
 import static java.util.Comparator.comparingDouble;
 import static java.util.Comparator.comparingInt;
 
-@SuppressWarnings("UnnecessaryLocalVariable")
-@Getter
 
 @Component
 @RequiredArgsConstructor
@@ -26,8 +23,8 @@ public class ShipmentRouteDomainService {
     private final MapApi mapApi;
 
 
-    public final ShipmentRoute findShipmentRoutes(UUID originHubId,
-                                                  Position destination) {
+    public ShipmentRoute findShipmentRoutes(UUID originHubId,
+                                            Position destination) {
 
         List<Hub> hubList = hubRepo.readAllHubs();
 
@@ -46,12 +43,12 @@ public class ShipmentRouteDomainService {
     }
 
 
-    public final LastHubToDestination findFinalHubToDestination(Position destinationPoint) {
+    public LastHubToDestination findFinalHubToDestination(Position destinationPoint) {
         return findFinalHubToDestination(hubRepo.readAllHubs(), destinationPoint);
     }
 
-    protected final LastHubToDestination findFinalHubToDestination(List<Hub> hubList,
-                                                                   Position destination) {
+    protected LastHubToDestination findFinalHubToDestination(List<Hub> hubList,
+                                                             Position destination) {
 
         assert (!hubList.isEmpty());
 
@@ -67,11 +64,11 @@ public class ShipmentRouteDomainService {
     }
 
 
-    public final Hub findNearestHub(Position target) {
+    public Hub findNearestHub(Position target) {
         return findNearestHub(target, hubRepo.readAllHubs());
     }
 
-    protected final Hub findNearestHub(Position target, List<Hub> hubList) {
+    protected Hub findNearestHub(Position target, List<Hub> hubList) {
 
         assert (!hubList.isEmpty());
 
@@ -83,15 +80,15 @@ public class ShipmentRouteDomainService {
     }
 
 
-    public final List<InterhubRoute> findShipmentInterhubRoutes(UUID originHubId,
-                                                                UUID destinationHubId) {
+    public List<InterhubRoute> findShipmentInterhubRoutes(UUID originHubId,
+                                                          UUID destinationHubId) {
 
         return findShipmentInterhubRoutes(originHubId, destinationHubId, hubRepo.readAllHubs());
     }
 
-    protected final List<InterhubRoute> findShipmentInterhubRoutes(UUID originHubId,
-                                                                   UUID destinationHubId,
-                                                                   List<Hub> hubList) {
+    protected List<InterhubRoute> findShipmentInterhubRoutes(UUID originHubId,
+                                                             UUID destinationHubId,
+                                                             List<Hub> hubList) {
 
         assert (originHubId != destinationHubId);
         assert (hubList.stream().anyMatch(hub -> hub.getId().equals(originHubId)));

--- a/com.sparta-express.hub/src/main/java/com/sparta_express/hub/presentation/controller/InterhubRoutesController.java
+++ b/com.sparta-express.hub/src/main/java/com/sparta_express/hub/presentation/controller/InterhubRoutesController.java
@@ -32,7 +32,7 @@ public class InterhubRoutesController {
             ) {
 
         LastHubToDestination lastHubToDestination
-                = shipmentRouteService.findFinalHubToDestination(destinationAddress);
+                = shipmentRouteService.findLastHubToDestination(destinationAddress);
 
         LastHubToDestinationRes lastHubToDestinationRes
                 = LastHubToDestinationRes.from(lastHubToDestination);


### PR DESCRIPTION

## 연관된 이슈

#13 

## 작업 내용

 cglib aop 적용되는 클래스(inteface상속 안받는클래스)의 final 메서드 충돌 제거

: interface의 구현 클래스가 아닌 경우 cglib방식의 aop가 적용, 이는 final메서드 사용시 메서드 오버라이딩 불가해 정상작동X

